### PR TITLE
Add `GridArray`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+nd = "nd"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0-pre"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -27,6 +28,7 @@ RavenWriteVTKExt = "WriteVTK"
 [compat]
 Adapt = "3"
 CUDA = "4"
+Compat = "3.42, 4"
 GPUArraysCore = "0.1"
 KernelAbstractions = "0.9"
 MPI = "0.20"

--- a/ext/RavenCUDAExt.jl
+++ b/ext/RavenCUDAExt.jl
@@ -9,6 +9,7 @@ isdefined(Base, :get_extension) ? (using CUDA.CUDAKernels) : (using ..CUDA.CUDAK
 
 Raven.get_backend(::Type{T}) where {T<:CuArray} = CUDABackend(; always_inline = true)
 Raven.arraytype(::Type{T}) where {T<:CuArray} = CuArray
+Raven.arraytype(::Type{T}) where {T<:CuDeviceArray} = CuArray
 
 Raven.pin(::Type{T}, A::Array) where {T<:CuArray} = CUDA.Mem.pin(A)
 

--- a/ext/RavenCUDAExt.jl
+++ b/ext/RavenCUDAExt.jl
@@ -33,4 +33,6 @@ function Raven.adaptsparse(::Type{T}, S) where {T<:CuArray}
     return Adapt.adapt(T, Raven.GeneralSparseMatrixCSC(S))
 end
 
+Adapt.adapt_storage(::CUDA.Adaptor, ::MPI.Comm) = nothing
+
 end # module RavenCUDAExt

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -1,6 +1,7 @@
 module Raven
 
 using Adapt
+using Compat
 using GPUArraysCore
 using KernelAbstractions
 using KernelAbstractions.Extras: @unroll
@@ -25,6 +26,7 @@ export flatten, unflatten
 export brick, coarsegrid
 
 export GridManager, generate
+export GridArray, components, sizewithghosts, viewwithghosts, parentwithghosts
 
 export adapt!
 
@@ -38,6 +40,7 @@ include("coarsegrids.jl")
 include("communication.jl")
 include("grids.jl")
 include("gridmanager.jl")
+include("gridarrays.jl")
 
 if !isdefined(Base, :get_extension)
     using Requires

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -49,7 +49,7 @@ argument.
 """
 get_backend(A) = get_backend(typeof(A))
 get_backend(::Type) = nothing
-get_backend(::Type{T}) where {T<:Array} = CPU()
+get_backend(::Type{T}) where {T<:Array} = CPU(; static = true)
 get_backend(::Type{T}) where {T<:AbstractArray} = get_backend(parenttype(T))
 
 arraytype(A) = arraytype(typeof(A))

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -61,7 +61,7 @@ end
 function flatten_builder(name, ::Type{T}, ::Type{U}, fname) where {T,U}
     newname = :(getfield($name, $(QuoteNode(fname))))
     if fieldtype(T, fname) <: U
-        return newname
+        return Expr(:tuple, newname)
     else
         return nested(newname, fieldtype(T, fname), U, flatten_builder, flatten_combiner)
     end

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -1,0 +1,441 @@
+function recursive_fieldtypes(::Type{T}, ::Type{U} = Real) where {T,U}
+    if T <: U
+        return (T,)
+    else
+        return recursive_fieldtypes.(fieldtypes(T), U)
+    end
+end
+
+@inline function insert(I::NTuple{N,Int}, ::Val{M}, i::Int) where {N,M}
+    m = M::Int
+    return (I[1:m-1]..., i, I[m:end]...)::NTuple{N + 1,Int}
+end
+
+"""
+    GridArray{T,N,A,G,F,L,C,D,W} <: AbstractArray{T,N}
+
+`N`-dimensional array of values of type `T` for each grid point using a
+struct-of-arrays like format that is GPU friendly.  Type `T` is assumed to be
+a hierarchical `struct` that can be `flatten`ed into an `NTuple{L,E<:Real}`.
+
+The backing data array will be of type `A{E}` and will have the fields of `T`
+indexed via index `F`.
+
+`GridArray` also stores values for the ghost cells of the grid which are
+accessible if `G==true`.
+"""
+struct GridArray{T,N,A,G,F,L,C,D,W} <: AbstractArray{T,N}
+    """MPI.Comm used for communication"""
+    comm::C
+    """View of the backing data array without the ghost cells"""
+    data::D
+    """Backing data array with the ghost cells"""
+    datawithghosts::W
+    """Dimensions of the array without the ghost cells"""
+    dims::NTuple{N,Int}
+    """Dimensions of the array with the ghost cells"""
+    dimswithghosts::NTuple{N,Int}
+end
+
+function GridArray{T}(
+    ::UndefInitializer,
+    ::Type{A},
+    dims::NTuple{N,Int},
+    dimswithghosts::NTuple{N,Int},
+    comm,
+    withghosts::Bool,
+    fieldindex::Integer,
+) where {T,A,N}
+    if !(all(dims[1:end-1] .== dimswithghosts[1:end-1]) && dims[end] <= dimswithghosts[end])
+        throw(DimensionMismatch(
+                "dims ($dims) must equal to dimswithghosts ($dimswithghosts) in all but the last dimension where it should be less than",
+            ),
+        )
+    end
+
+    types = flatten(recursive_fieldtypes(T), DataType)
+
+    L = length(types)::Int
+    if L == 0
+        throw(ArgumentError("Type T has no Real fields"))
+    end
+
+    E = first(types)
+    if !allequal(types)
+        throw(ArgumentError("Type T has different field types: $types"))
+    end
+
+    datawithghosts = A{E}(undef, insert(dimswithghosts, Val(fieldindex), L))
+    data = view(datawithghosts, (ntuple(_->Colon(), Val(N))..., Base.OneTo(dims[end]))...)
+
+    C = typeof(comm)
+    D = typeof(data)
+    W = typeof(datawithghosts)
+
+    return GridArray{T,N,A,withghosts,fieldindex,L,C,D,W}(
+        comm,
+        data,
+        datawithghosts,
+        dims,
+        dimswithghosts,
+    )
+end
+
+"""
+    GridArray{T}(undef, grid::Grid)
+
+Create an array containing elements of type `T` for each point in the grid
+(including the ghost cells).  The dimensions of the array is
+`(size(celltype(grid))..., length(grid))` as the ghost cells are hidden by
+default.
+
+The type `T` is assumed to be able to be interpreted into an `NTuple{M,L}`.
+Some example types (some using `StructArrays`) are:
+- `T = NamedTuple{(:E,:B),Tuple{SVector{3,ComplexF64},SVector{3,ComplexF64}}}`
+- `T = NTuple{5,Int64}`
+- `T = SVector{5,Int64}`
+- `T = ComplexF32`
+- `T = Float32`
+
+Instead of using an array-of-struct style storage, a GPU efficient
+struct-of-arrays like storage is used.  For example, instead of storing data
+like
+```julia-repl
+julia> T = Tuple{Int,Int};
+julia> data = Array{T}(undef, 3, 4, 2); a .= Ref((1,2))
+3×4 Matrix{Tuple{Int64, Int64}}:
+ (1, 2)  (1, 2)  (1, 2)  (1, 2)
+ (1, 2)  (1, 2)  (1, 2)  (1, 2)
+ (1, 2)  (1, 2)  (1, 2)  (1, 2)
+```
+the data would be stored in the order
+```julia-repl
+julia> permutedims(reinterpret(reshape, Int, data), (2,3,1,4))
+3×4×2×2 Array{Int64, 4}:
+[:, :, 1, 1] =
+ 1  1  1  1
+ 1  1  1  1
+ 1  1  1  1
+
+[:, :, 2, 1] =
+ 2  2  2  2
+ 2  2  2  2
+ 2  2  2  2
+
+[:, :, 1, 2] =
+ 1  1  1  1
+ 1  1  1  1
+ 1  1  1  1
+
+[:, :, 2, 2] =
+ 2  2  2  2
+ 2  2  2  2
+ 2  2  2  2
+```
+For a `GridArray` the indices before the ones associated with `T` (the first
+two in the example above) are associated with the degrees-of-freedoms of the
+cells.  The one after is associated with the number of cells.
+"""
+function GridArray{T}(::UndefInitializer, grid::Grid) where {T}
+    A = arraytype(grid)
+    dims = (size(celltype(grid))..., Int(numcells(grid, Val(false))))
+    dimswithghosts = (size(celltype(grid))..., Int(numcells(grid, Val(true))))
+    F = ndims(celltype(grid)) + 1
+
+    return GridArray{T}(undef, A, dims, dimswithghosts, comm(grid), false, F)
+end
+
+function Base.showarg(io::IO, a::GridArray{T,N,A,G,F}, toplevel) where {T,N,A,G,F}
+    !toplevel && print(io, "::")
+    print(io, "GridArray{", T, ",", N, ",", A, ",", G, ",", F, "}")
+    toplevel && print(io, " with data eltype ", eltype(parent(a)))
+    return
+end
+
+"""
+    viewwithghosts(A::GridArray)
+
+Return a `GridArray` with the same data as `A` but with the ghost cells accessible.
+"""
+@inline function viewwithghosts(a::GridArray{T,N,A,G,F,L,C,D,W}) where {T,N,A,G,F,L,C,D,W}
+    GridArray{T,N,A,true,F,L,C,D,W}(
+        a.comm,
+        a.data,
+        a.datawithghosts,
+        a.dims,
+        a.dimswithghosts,
+    )
+end
+
+"""
+    get_backend(A::GridArray) -> KernelAbstractions.Backend
+
+Returns the `KernelAbstractions.Backend` used to launch kernels interacting
+with `A`.
+"""
+@inline get_backend(::GridArray{T,N,A}) where {T,N,A} = get_backend(A)
+"""
+    arraytype(A::GridArray) -> DataType
+
+Returns the `DataType` used to store the data, e.g., `Array` or `CuArray`.
+"""
+@inline arraytype(::GridArray{T,N,A}) where {T,N,A} = A
+"""
+    showingghosts(A::GridArray) -> Bool
+
+Predicate indicating if the ghost layer is accessible to `A`.
+"""
+@inline showingghosts(::GridArray{T,N,A,G}) where {T,N,A,G} = G
+"""
+    fieldindex(A::GridArray{T})
+
+Returns the index used in `A.data` to store the fields of `T`.
+"""
+@inline fieldindex(::GridArray{T,N,A,G,F}) where {T,N,A,G,F} = F
+"""
+    fieldslength(A::GridArray{T})
+
+Returns the number of fields used to store `T`.
+"""
+@inline fieldslength(::GridArray{T,N,A,G,F,L}) where {T,N,A,G,F,L} = L
+
+"""
+    comm(A::GridArray) -> MPI.Comm
+
+MPI communicator used by `A`.
+"""
+@inline comm(a::GridArray) = a.comm
+
+@inline Base.parent(a::GridArray{T,N,A,G}) where {T,N,A,G} =
+    ifelse(G, a.datawithghosts, a.data)
+
+"""
+    sizewithghosts(A::GridArray)
+
+Return the underlying "parent array" which includes the ghost cells.
+"""
+@inline parentwithghosts(a::GridArray) = a.datawithghosts
+
+@inline Base.size(a::GridArray{T,N,A,false}) where {T,N,A} = a.dims
+@inline Base.size(a::GridArray{T,N,A,true}) where {T,N,A} = a.dimswithghosts
+
+"""
+    sizewithghosts(A::GridArray)
+
+Return a tuple containing the dimensions of `A` including the ghost cells.
+"""
+@inline sizewithghosts(a::GridArray) = a.dimswithghosts
+
+function Base.similar(a::GridArray{S,N,A,G,F}, ::Type{T}, dims::Dims) where {S,N,A,G,F,T}
+    GridArray{T}(undef, A, dims, a.dimswithghosts, comm(a), G, F)
+end
+
+@inline function Base.getindex(
+    a::GridArray{T,N,A,G,F,L},
+    I::Vararg{Int,N},
+) where {T,N,A,G,F,L}
+    @boundscheck Base.checkbounds_indices(Bool, axes(a), I) || Base.throw_boundserror(a, I)
+    data = parent(a)
+    d = ntuple(
+        i -> (@inbounds getindex(data, insert(I, Val(F), i)...)),
+        Val(L),
+    )::NTuple{L,eltype(data)}
+    return unflatten(T, d)
+end
+
+@inline function Base.setindex!(
+    a::GridArray{T,N,A,G,F,L},
+    v::T,
+    I::Vararg{Int,N},
+) where {T,N,A,G,F,L}
+    @boundscheck Base.checkbounds_indices(Bool, axes(a), I) || Base.throw_boundserror(a, I)
+    data = parent(a)
+    vt = flatten(v)
+    @unroll for i = 1:L
+        @inbounds setindex!(data, vt[i], insert(I, Val(F), i)...)
+    end
+end
+
+LinearAlgebra.norm(a::GridArray) = sqrt(MPI.Allreduce(norm(parent(a))^2, +, comm(a)))
+
+@kernel function fill_kernel!(a, x)
+    I = @index(Global)
+    @inbounds a[I] = x
+end
+
+function Base.fill!(a::GridArray, x)
+    fill_kernel!(get_backend(a), 256)(a, x, ndrange = length(a))
+end
+
+function Adapt.adapt_structure(to, a::GridArray{T,N,A,G,F,L}) where {T,N,A,G,F,L}
+    newcomm = Adapt.adapt(to, a.comm)
+    newdatawithghosts = Adapt.adapt(to, a.datawithghosts)
+    newdata = view(newdatawithghosts, Base.OneTo.(insert(a.dims, Val(F), L))...)
+
+    NA = arraytype(newdatawithghosts)
+    NC = typeof(newcomm)
+    ND = typeof(newdata)
+    NW = typeof(newdatawithghosts)
+
+    GridArray{T,N,NA,G,F,L,NC,ND,NW}(
+        newcomm,
+        newdata,
+        newdatawithghosts,
+        a.dims,
+        a.dimswithghosts,
+    )
+end
+
+Base.BroadcastStyle(::Type{<:GridArray}) = Broadcast.ArrayStyle{GridArray}()
+
+cat_gridarrays(t::Broadcast.Broadcasted, rest...) =
+    (cat_gridarrays(t.args...)..., cat_gridarrays(rest...)...)
+cat_gridarrays(t::GridArray, rest...) = (t, cat_gridarrays(rest...)...)
+cat_gridarrays(::Any, rest...) = cat_gridarrays(rest...)
+cat_gridarrays() = ()
+
+function Base.similar(
+    bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{GridArray}},
+    ::Type{T},
+) where {T}
+    dims = length.(axes(bc))
+
+    gridarrays = cat_gridarrays(bc)
+
+    a = first(gridarrays)
+    A = arraytype(a)
+    G = showingghosts(a)
+    F = fieldindex(a)
+    elemdims = sizewithghosts(a)[M+1:end]
+
+    for b in gridarrays
+        if A != arraytype(b) ||
+           G != showingghosts(b) ||
+           F != fieldindex(b) ||
+           MPI.Comm_compare(comm(a), comm(b)) != MPI.IDENT ||
+           elemdims != sizewithghosts(b)[F:end]
+            throw(ArgumentError("Incompatible GridArray arguments in broadcast"))
+        end
+    end
+
+    return GridArray{T}(A, dims, (dims[1:F-1]..., elemdims...), comm(a), G, F)
+end
+
+@kernel function broadcast_kernel!(dest, bc)
+    I = @index(Global)
+    @inbounds dest[I] = bc[I]
+end
+
+@inline function Base.copyto!(dest::GridArray, bc::Broadcast.Broadcasted{Nothing})
+    axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
+    isempty(dest) && return dest
+
+    bcprime = Broadcast.preprocess(dest, bc)
+
+    broadcast_kernel!(get_backend(dest), 256)(dest, bcprime, ndrange = length(dest))
+
+    return dest
+end
+
+@inline function Base.copyto!(dest::GridArray, src::GridArray)
+    return copyto!(dest.datawithghosts, src.datawithghosts)
+end
+
+# We follow GPUArrays approach of coping the whole array to the host when
+# outputting a GridArray backed by GPU arrays.
+convert_to_cpu(xs) = Adapt.adapt_structure(Array, xs)
+function Base.print_array(io::IO, X::GridArray{<:Any,0,<:AbstractGPUArray})
+    X = convert_to_cpu(X)
+    isassigned(X) ? show(io, X[]) : print(io, "#undef")
+end
+Base.print_array(io::IO, X::GridArray{<:Any,1,<:AbstractGPUArray}) =
+    Base.print_matrix(io, convert_to_cpu(X))
+Base.print_array(io::IO, X::GridArray{<:Any,2,<:AbstractGPUArray}) =
+    Base.print_matrix(io, convert_to_cpu(X))
+Base.print_array(io::IO, X::GridArray{<:Any,<:Any,<:AbstractGPUArray}) =
+    Base.show_nd(io, convert_to_cpu(X), Base.print_matrix, true)
+function Base.show_nd(
+    io::IO,
+    X::Raven.GridArray{<:Any,<:Any,<:AbstractGPUArray},
+    print_matrix::Function,
+    show_full::Bool,
+)
+    Base.show_nd(io, Raven.convert_to_cpu(X), print_matrix, show_full)
+end
+
+@inline components(::Type{T}) where {T} = fieldtypes(T)
+@inline components(::Type{<:NamedTuple{E,T}}) where {E,T} = NamedTuple{E}(fieldtypes(T))
+@inline components(::Type{T}) where {T<:Complex} = NamedTuple{(:re, :im)}(fieldtypes(T))
+@inline components(::Type{T}) where {T<:SArray} = fieldtypes(fieldtype(T, 1))
+@inline components(::Type{T}) where {T<:Real} = (T,)
+
+@inline function componentoffset(::Type{T}, ::Type{E}, i::Int) where {T<:SArray,E}
+    return componentoffset(fieldtype(T, 1), E, i)
+end
+
+@inline function componentoffset(::Type{T}, ::Type{E}, i::Int) where {T,E}
+    if T <: E
+        return 0
+    else
+        return Int(fieldoffset(T, i) ÷ sizeof(E))
+    end
+end
+
+@inline function ncomponents(::Type{T}, ::Type{E}) where {T,E}
+    return Int(sizeof(T) ÷ sizeof(E))
+end
+
+"""
+    components(A::GridArray{T})
+
+Splits `A` into a tuple of `GridArray`s where there is one for each component
+of `T`.
+
+Note, the data for the components is shared with the original array.
+
+For example, if `A isa GridArray{SVector{3, Float64}}` then a tuple of type
+`NTuple{3, GridArray{Float64}}` would be returned.
+"""
+function components(a::GridArray{T,N,A,G,F}) where {T,N,A,G,F}
+    componenttypes = components(T)
+    E = eltype(a.datawithghosts)
+
+    c = comm(a)
+    dims = size(a)
+    dimswithghosts = sizewithghosts(a)
+
+    comps = ntuple(length(componenttypes)) do n
+        Tn = componenttypes[n]
+
+        r = (1:ncomponents(Tn, E)) .+ componentoffset(T, E, n)
+
+        datawithghosts =
+            view(a.datawithghosts, setindex(axes(a.datawithghosts), r, F)...)
+        data = view(a.data, setindex(axes(a.data), r, F)...)
+
+        L = length(r)
+        C = typeof(c)
+        D = typeof(data)
+        W = typeof(datawithghosts)
+
+        GridArray{Tn,N,A,G,F,L,C,D,W}(c, data, datawithghosts, dims, dimswithghosts)
+    end
+
+    if T <: Union{NamedTuple,FieldArray}
+        comps = NamedTuple{fieldnames(T)}(comps)
+    end
+
+    if T <: SVector
+        if Size(T) == Size(1)
+            comps = NamedTuple{(:x,)}(comps)
+        elseif Size(T) == Size(2)
+            comps = NamedTuple{(:x, :y)}(comps)
+        elseif Size(T) == Size(3)
+            comps = NamedTuple{(:x, :y, :z)}(comps)
+        elseif Size(T) == Size(4)
+            comps = NamedTuple{(:x, :y, :z, :w)}(comps)
+        end
+    end
+
+    return comps
+end

--- a/src/gridmanager.jl
+++ b/src/gridmanager.jl
@@ -348,6 +348,7 @@ function generate(warp::Function, gm::GridManager)
     end
 
     return Grid(
+        comm(gm),
         part,
         nparts,
         referencecell(gm),

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -9,6 +9,7 @@ arraytype(grid::AbstractGrid) = arraytype(typeof(grid))
 celltype(grid::AbstractGrid) = celltype(typeof(grid))
 
 struct Grid{C<:AbstractCell,P,L,T,F,PN,N,CTOD,DTOC} <: AbstractGrid{C}
+    comm::MPI.Comm
     part::Int
     nparts::Int
     cell::C
@@ -23,6 +24,8 @@ struct Grid{C<:AbstractCell,P,L,T,F,PN,N,CTOD,DTOC} <: AbstractGrid{C}
     continuoustodiscontinuous::CTOD
     discontinuoustocontinuous::DTOC
 end
+
+comm(grid::Grid) = grid.comm
 
 referencecell(grid::Grid) = grid.cell
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,8 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -1,0 +1,105 @@
+using CUDA
+using CUDA.CUDAKernels
+using MPI
+using Test
+using Raven
+using Raven.StaticArrays
+
+MPI.Init()
+
+struct Stiffness <: FieldArray{Tuple{2,2},Float64,2}
+    xx::Float64
+    yx::Float64
+    xy::Float64
+    yy::Float64
+end
+
+function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
+    @testset "GridArray ($N, $AT, $FT)" begin
+        cell = LobattoCell{Tuple{N...},Float64,AT}()
+        gm = GridManager(cell, Raven.brick(K...); min_level = 1)
+        grid = generate(gm)
+
+        val = (E = SVector{3,Complex{FT}}(1, 3, 5), B = SVector{3,Complex{FT}}(7, 9, 11))
+        T = typeof(val)
+        A = GridArray{T}(undef, grid)
+        @test eltype(A) == T
+
+        A .= Ref(val)
+        @test CUDA.@allowscalar A[1] == val
+
+        Adata = AT(parent(A))
+        colons = ntuple(_ -> Colon(), Val(length(N)))
+        for i = 1:2:11
+            @test all(Adata[colons..., i, :] .== i)
+        end
+        for i = 2:2:12
+            @test all(Adata[colons..., i, :] .== 0)
+        end
+
+        val2 =
+            (E = SVector{3,Complex{FT}}(2, 6, 10), B = SVector{3,Complex{FT}}(14, 18, 22))
+        B = Raven.viewwithghosts(A)
+        B .= Ref(val2)
+        @test CUDA.@allowscalar B[end] == val2
+
+        Adatadata = parentwithghosts(A)
+        colons = ntuple(_ -> Colon(), Val(length(N)))
+        for i = 1:2:11
+            @test all(Adatadata[colons..., i, :] .== 2i)
+        end
+        for i = 2:2:12
+            @test all(Adatadata[colons..., i, :] .== 0)
+        end
+
+        L = length(flatten(val))
+
+        @test arraytype(A) <: AT
+        @test Raven.showingghosts(A) == false
+        @test Raven.fieldindex(A) == length(N) + 1
+        @test Raven.fieldslength(A) == L
+
+        @test size(A) == (size(cell)..., numcells(grid))
+        @test sizewithghosts(A) == (size(cell)..., numcells(grid, Val(true)))
+        @test size(parent(A)) == (size(cell)..., L, numcells(grid))
+        @test size(parentwithghosts(A)) == (size(cell)..., L, numcells(grid, Val(true)))
+
+        C = components(A)
+        @test length(C) == 2
+        @test C isa NamedTuple{(:E, :B)}
+
+        @test C[1] isa GridArray{typeof(val[1])}
+        @test C[2] isa GridArray{typeof(val[2])}
+
+        D = components(C[1])
+        @test length(D) == 3
+        @test D[1] isa GridArray{Complex{FT}}
+        @test D[2] isa GridArray{Complex{FT}}
+        @test D[3] isa GridArray{Complex{FT}}
+
+        E = components(D[1])
+        @test length(E) == 2
+        @test E[1] isa GridArray{FT}
+        @test E[2] isa GridArray{FT}
+
+        F = components(E[1])
+        @test length(F) == 1
+        @test F[1] isa GridArray{FT}
+
+        A = GridArray{Stiffness}(undef, grid)
+        @test eltype(A) == Stiffness
+        @test components(A) isa NamedTuple{(:xx, :yx, :xy, :yy)}
+    end
+end
+
+function main()
+    test((2, 3), (2, 1), Float64, Array)
+    test((2, 3, 2), (1, 2, 1), Float64, Array)
+
+    if CUDA.functional()
+        test((2, 3), (2, 1), Float32, CuArray)
+        test((2, 3, 2), (1, 2, 1), Float32, CuArray)
+    end
+end
+
+main()


### PR DESCRIPTION
- Allow structs with an MPI.Comm in a CUDA kernels
- Include MPI.Comm in the grid
- Use static thread scheduling on the CPU
- Rename CUDA extension
- Allow `flatten` to support more field types
- Add array type for `CuDeviceArray`
- Add grid array type
