### PR TITLE
Rename CUDA extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [extensions]
-CUDAExt = "CUDA"
+RavenCUDAExt = "CUDA"
 
 [compat]
 Adapt = "3"

--- a/ext/RavenCUDAExt.jl
+++ b/ext/RavenCUDAExt.jl
@@ -1,4 +1,4 @@
-module CUDAExt
+module RavenCUDAExt
 
 import Raven
 import Adapt
@@ -33,4 +33,4 @@ function Raven.adaptsparse(::Type{T}, S) where {T<:CuArray}
     return Adapt.adapt(T, Raven.GeneralSparseMatrixCSC(S))
 end
 
-end # module CUDAExt
+end # module RavenCUDAExt

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -45,7 +45,9 @@ end
 
 @static if !isdefined(Base, :get_extension)
     function __init__()
-        @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" include("../ext/CUDAExt.jl")
+        @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" include(
+            "../ext/RavenCUDAExt.jl",
+        )
     end
 end
 


### PR DESCRIPTION
There was a problem precompiling MPI in the Raven package environment
because both MPI and Raven have extensions with the name `CUDAExt`.
We avoid this issue by renaming Raven's CUDA extension.
