### PR TITLE
Show GPUArray backed GeneralSparseMatrixCSC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0-pre"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
@@ -26,6 +27,7 @@ RavenWriteVTKExt = "WriteVTK"
 [compat]
 Adapt = "3"
 CUDA = "4"
+GPUArraysCore = "0.1"
 KernelAbstractions = "0.9"
 MPI = "0.20"
 OneDimensionalNodes = "1"

--- a/src/Raven.jl
+++ b/src/Raven.jl
@@ -1,6 +1,7 @@
 module Raven
 
 using Adapt
+using GPUArraysCore
 using KernelAbstractions
 using KernelAbstractions.Extras: @unroll
 using LinearAlgebra

--- a/test/sparsearrays.jl
+++ b/test/sparsearrays.jl
@@ -1,12 +1,25 @@
 @testset "Sparse Arrays" begin
     S = sparse([1], [2], [3])
     G = Raven.GeneralSparseMatrixCSC(S)
-    H = Adapt.adapt(Array, G)
+
+    AT = CUDA.functional() ? CuArray : Array
+    H = Adapt.adapt(AT, G)
 
     for A in (G, H)
         @test size(S) == size(A)
-        @test SparseArrays.getcolptr(S) == SparseArrays.getcolptr(A)
-        @test rowvals(S) == rowvals(A)
-        @test nonzeros(S) == nonzeros(A)
+        @test SparseArrays.getcolptr(S) == Array(SparseArrays.getcolptr(A))
+        @test rowvals(S) == Array(rowvals(A))
+        @test nonzeros(S) == Array(nonzeros(A))
+        @test nnz(S) == nnz(A)
+
+        @static if VERSION >= v"1.7"
+            ioS = IOBuffer()
+            ioA = IOBuffer()
+            show(ioS, S)
+            show(ioA, A)
+            @test take!(ioS) == take!(ioA)
+
+            @test_nowarn show(IOBuffer(), MIME"text/plain"(), A)
+        end
     end
 end


### PR DESCRIPTION
This code allows the printing of `GPUArray` backed
`GeneralSparseMatrixCSC`s by allowing scalar indexing and copying to the
host as needed.
