### PR TITLE
Cleanup GridArrays

### DIFF
--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -326,8 +326,8 @@ end
 
 @kernel function broadcast_kernel!(dest, bc)
     i = @index(Global)
-    I = CartesianIndices(dest)[i]
-    dest[I] = bc[I]
+    @inbounds I = CartesianIndices(dest)[i]
+    @inbounds dest[I] = bc[I]
 end
 
 @inline function Base.copyto!(dest::GridArray, bc::Broadcast.Broadcasted{Nothing})

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -346,6 +346,11 @@ end
     return dest
 end
 
+function Base.copy(a::GridArray)
+    b = similar(a)
+    copyto!(b, a)
+end
+
 # We follow GPUArrays approach of coping the whole array to the host when
 # outputting a GridArray backed by GPU arrays.
 convert_to_cpu(xs) = Adapt.adapt_structure(Array, xs)

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -248,12 +248,12 @@ end
 
 @inline function Base.setindex!(
     a::GridArray{T,N,A,G,F,L},
-    v::T,
+    v,
     I::Vararg{Int,N},
 ) where {T,N,A,G,F,L}
     @boundscheck Base.checkbounds_indices(Bool, axes(a), I) || Base.throw_boundserror(a, I)
     data = parent(a)
-    vt = flatten(v)
+    vt = flatten(convert(T, v)::T)
     @unroll for i = 1:L
         @inbounds setindex!(data, vt[i], insert(I, Val(F), i)...)
     end

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -342,7 +342,8 @@ end
 end
 
 @inline function Base.copyto!(dest::GridArray, src::GridArray)
-    return copyto!(dest.datawithghosts, src.datawithghosts)
+    copyto!(dest.datawithghosts, src.datawithghosts)
+    return dest
 end
 
 # We follow GPUArrays approach of coping the whole array to the host when

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -266,8 +266,8 @@ LinearAlgebra.norm(a::GridArray) = sqrt(MPI.Allreduce(norm(parent(a))^2, +, comm
     @inbounds a[I] = x
 end
 
-function Base.fill!(a::GridArray, x)
-    fill_kernel!(get_backend(a), 256)(a, x, ndrange = length(a))
+function Base.fill!(a::GridArray{T}, x) where {T}
+    fill_kernel!(get_backend(a), 256)(a, convert(T, x)::T, ndrange = length(a))
 end
 
 function Adapt.adapt_structure(to, a::GridArray{T,N,A,G,F,L}) where {T,N,A,G,F,L}

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -47,7 +47,8 @@ function GridArray{T}(
     fieldindex::Integer,
 ) where {T,A,N}
     if !(all(dims[1:end-1] .== dimswithghosts[1:end-1]) && dims[end] <= dimswithghosts[end])
-        throw(DimensionMismatch(
+        throw(
+            DimensionMismatch(
                 "dims ($dims) must equal to dimswithghosts ($dimswithghosts) in all but the last dimension where it should be less than",
             ),
         )
@@ -66,7 +67,7 @@ function GridArray{T}(
     end
 
     datawithghosts = A{E}(undef, insert(dimswithghosts, Val(fieldindex), L))
-    data = view(datawithghosts, (ntuple(_->Colon(), Val(N))..., Base.OneTo(dims[end]))...)
+    data = view(datawithghosts, (ntuple(_ -> Colon(), Val(N))..., Base.OneTo(dims[end]))...)
 
     C = typeof(comm)
     D = typeof(data)

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -146,6 +146,8 @@ function GridArray{T}(::UndefInitializer, grid::Grid) where {T}
     return GridArray{T}(undef, A, dims, dimswithghosts, comm(grid), false, F)
 end
 
+GridArray(::UndefInitializer, grid::Grid) = GridArray{Float64}(undef, grid)
+
 function Base.showarg(io::IO, a::GridArray{T,N,A,G,F}, toplevel) where {T,N,A,G,F}
     !toplevel && print(io, "::")
     print(io, "GridArray{", T, ",", N, ",", A, ",", G, ",", F, "}")

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -27,11 +27,11 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
         @test A isa GridArray{Float64}
         @test arraytype(A) <: AT
 
-        val = (E = SVector{3,Complex{FT}}(1, 3, 5), B = SVector{3,Complex{FT}}(7, 9, 11))
-        T = typeof(val)
+        T = NamedTuple{(:E, :B),Tuple{SVector{3,Complex{FT}},SVector{3,Complex{FT}}}}
         A = GridArray{T}(undef, grid)
         @test eltype(A) == T
 
+        val = (E = SA[1, 3, 5], B = SA[7, 9, 11])
         A .= Ref(val)
         @test CUDA.@allowscalar A[1] == val
 
@@ -59,7 +59,8 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
             @test all(Adatadata[colons..., i, :] .== 0)
         end
 
-        L = length(flatten(val))
+        cval = convert(T, val)
+        L = length(flatten(cval))
 
         @test arraytype(A) <: AT
         @test Raven.showingghosts(A) == false
@@ -75,8 +76,8 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
         @test length(C) == 2
         @test C isa NamedTuple{(:E, :B)}
 
-        @test C[1] isa GridArray{typeof(val[1])}
-        @test C[2] isa GridArray{typeof(val[2])}
+        @test C[1] isa GridArray{typeof(cval[1])}
+        @test C[2] isa GridArray{typeof(cval[2])}
 
         D = components(C[1])
         @test length(D) == 3
@@ -97,7 +98,7 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
             E = SVector{3,Complex{FT}}(1 + 1im, 1 + 1im, 1 + 1im),
             B = SVector{3,Complex{FT}}(1 + 1im, 1 + 1im, 1 + 1im),
         )
-        L = length(flatten(val))
+        L = length(flatten(cval))
         B = Raven.viewwithghosts(A)
         B .= Ref(val3)
         normA = sqrt(FT(L * prod(N) * prod(K) * (2^(length(K) * minlvl))))

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -116,6 +116,9 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
         A .= FT(2)
         B = 1 ./ A
         @test all(adapt(Array, (B .== FT(0.5))))
+
+        B = copy(A)
+        @test all(adapt(Array, (B .== A)))
     end
 end
 

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -23,6 +23,10 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
         gm = GridManager(cell, Raven.brick(K...); min_level = minlvl)
         grid = generate(gm)
 
+        A = GridArray(undef, grid)
+        @test A isa GridArray{Float64}
+        @test arraytype(A) <: AT
+
         val = (E = SVector{3,Complex{FT}}(1, 3, 5), B = SVector{3,Complex{FT}}(7, 9, 11))
         T = typeof(val)
         A = GridArray{T}(undef, grid)

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -44,6 +44,10 @@ function test(N, K, ::Type{FT}, ::Type{AT}) where {FT,AT}
             @test all(Adata[colons..., i, :] .== 0)
         end
 
+        val = (E = SA[2, 1, 3], B = SA[0, 2, 1])
+        fill!(A, val)
+        @test CUDA.@allowscalar A[1] == val
+
         val2 =
             (E = SVector{3,Complex{FT}}(2, 6, 10), B = SVector{3,Complex{FT}}(14, 18, 22))
         B = Raven.viewwithghosts(A)


### PR DESCRIPTION
- Fix formatting
- Default `eltype` of `GridArray` to `Float64`
- Use `@inbounds` in `GridArray` broadcast indexing
- Fix return of `copyto!(::GridArray, ::GridArray)`
- Convert `setindex!` values for `GridArray`
- Convert value when filling `GridArray`s
- Add `copy` for `GridArray`
