### PR TITLE
Communicate `GridArray`s

### DIFF
--- a/misc/git/hooks/pre-commit
+++ b/misc/git/hooks/pre-commit
@@ -9,6 +9,8 @@
 JFDIR=$HOME/.local/share/nvim/site/pack/packer/start/JuliaFormatter.vim
 JLFILES=$(git diff --name-only --diff-filter=AM HEAD | grep '.*\.jl$')
 
+export GIT_DIR="${GIT_DIR-$(git rev-parse --git-common-dir)}"
+
 for JLFILE in $JLFILES;
 do
   MKTEMPLATE=$(basename "$JLFILE").XXXXXXXX.jl

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -103,3 +103,5 @@ function numbercontiguous(::Type{T}, A; by = identity) where {T}
 
     return B
 end
+
+viewwithghosts(A::AbstractArray) = A

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -235,6 +235,7 @@ function finish!(A, cm::CommManagerBuffered)
     MPI.Waitall(cm.recvrequests)
     MPI.Waitall(cm.sendrequests)
 
+    A = viewwithghosts(A)
     A[cm.pattern.recvindices] .= cm.recvbufferdevice
 
     return
@@ -283,6 +284,7 @@ function start!(A, cm::CommManagerTripleBuffered)
         cooperative_testall(cm.recvrequests)
         copyto!(cm.recvbufferhost, cm.recvbuffercomm)
         KernelAbstractions.copyto!(backend, cm.recvbufferdevice, cm.recvbufferhost)
+        A = viewwithghosts(A)
         A[cm.pattern.recvindices] .= cm.recvbufferdevice
         KernelAbstractions.synchronize(backend)
     end

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -217,6 +217,8 @@ get_backend(cm::AbstractCommManager) = get_backend(arraytype(cm.pattern))
 
 function progress(::AbstractCommManager)
     MPI.Iprobe(MPI.ANY_SOURCE, MPI.ANY_TAG, MPI.COMM_WORLD)
+
+    return
 end
 
 function start!(A, cm::CommManagerBuffered)
@@ -225,6 +227,8 @@ function start!(A, cm::CommManagerBuffered)
 
     MPI.Startall(cm.recvrequests)
     MPI.Startall(cm.sendrequests)
+
+    return
 end
 
 function finish!(A, cm::CommManagerBuffered)
@@ -232,6 +236,8 @@ function finish!(A, cm::CommManagerBuffered)
     MPI.Waitall(cm.sendrequests)
 
     A[cm.pattern.recvindices] .= cm.recvbufferdevice
+
+    return
 end
 
 function cooperative_testall(requests)
@@ -289,11 +295,15 @@ function start!(A, cm::CommManagerTripleBuffered)
         MPI.Startall(cm.sendrequests)
         cooperative_testall(cm.sendrequests)
     end
+
+    return
 end
 
 function finish!(_, cm::CommManagerTripleBuffered)
     cooperative_wait(cm.recvtask[])
     cooperative_wait(cm.sendtask[])
+
+    return
 end
 
 function share!(A, cm::AbstractCommManager)
@@ -302,4 +312,6 @@ function share!(A, cm::AbstractCommManager)
     progress(cm)
 
     finish!(A, cm)
+
+    return
 end

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -160,7 +160,7 @@ end
 
 Return a `GridArray` with the same data as `A` but with the ghost cells accessible.
 """
-@inline function viewwithghosts(a::GridArray{T,N,A,G,F,L,C,D,W}) where {T,N,A,G,F,L,C,D,W}
+@inline function viewwithghosts(a::GridArray{T,N,A,false,F,L,C,D,W}) where {T,N,A,F,L,C,D,W}
     GridArray{T,N,A,true,F,L,C,D,W}(
         a.comm,
         a.data,

--- a/src/gridarrays.jl
+++ b/src/gridarrays.jl
@@ -257,6 +257,7 @@ end
     @unroll for i = 1:L
         @inbounds setindex!(data, vt[i], insert(I, Val(F), i)...)
     end
+    return a
 end
 
 LinearAlgebra.norm(a::GridArray) = sqrt(MPI.Allreduce(norm(parent(a))^2, +, comm(a)))

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -8,4 +8,7 @@
     B = Raven.numbercontiguous(Int32, A, by = x -> -x)
     @test eltype(B) == Int32
     @test B == [1, 3, 2, 4, 2]
+
+    A = [1, 2]
+    @test viewwithghosts(A) == A
 end

--- a/test/mpitest_n2_commgridarrays.jl
+++ b/test/mpitest_n2_commgridarrays.jl
@@ -1,0 +1,57 @@
+using CUDA: BackToCPU
+using CUDA
+using MPI
+using Test
+using Raven
+using Raven.StaticArrays
+using Raven.Adapt
+
+MPI.Init()
+
+function test(::Type{FT}, ::Type{AT}) where {FT,AT}
+    @testset "Communicate GridArray ($AT, $FT)" begin
+        N = (3, 2)
+        K = (2, 1)
+        min_level = 1
+        cell = LobattoCell{Tuple{N...},Float64,AT}()
+        gm = GridManager(cell, Raven.brick(K...); min_level)
+        grid = generate(gm)
+
+        T = SVector{2,FT}
+        cm = Raven.commmanager(T, Raven.comm(grid), grid.nodecommpattern, 1)
+        A = GridArray{T}(undef, grid)
+
+        nan = convert(FT, NaN)
+
+        viewwithghosts(A) .= Ref((nan, nan))
+        A .= Ref((MPI.Comm_rank(Raven.comm(grid)) + 1, 0))
+
+        Raven.share!(A, cm)
+
+        @test all(A.data[:, :, 1, :] .== MPI.Comm_rank(Raven.comm(grid)) + 1)
+        @test all(A.data[:, :, 2, :] .== 0)
+
+        @test MPI.Comm_size(Raven.comm(grid)) == 2
+        r = MPI.Comm_rank(Raven.comm(grid))
+
+        if r == 0
+            @test all(A.datawithghosts[2:3, :, :, 5:6] .=== nan)
+            @test all(A.datawithghosts[1, :, 1, 5:6] .== 2)
+            @test all(A.datawithghosts[1, :, 2, 5:6] .== 0)
+        elseif r == 1
+            @test all(A.datawithghosts[1:2, :, :, 5:6] .=== nan)
+            @test all(A.datawithghosts[3, :, 1, 5:6] .== 1)
+            @test all(A.datawithghosts[3, :, 2, 5:6] .== 0)
+        end
+    end
+end
+
+function main()
+    test(Float64, Array)
+
+    if CUDA.functional()
+        test(Float32, CuArray)
+    end
+end
+
+main()

--- a/test/mpitest_n3_communication.jl
+++ b/test/mpitest_n3_communication.jl
@@ -106,10 +106,10 @@ let
         data4 = CuArray(data4)
 
         pattern = Raven.CommPattern{CuArray}(
-            recvindices,
+            CuArray(recvindices),
             recvranks,
             recvrankindices,
-            sendindices,
+            CuArray(sendindices),
             sendranks,
             sendrankindices,
         )


### PR DESCRIPTION
- In `Base.setindex!(a::GridArray, v, I)` return `a`
- Teach `viewwithghost` about abstract arrays
- Return `nothing` from communication functions
- Teach communication manager about `GridArray`s
- Only create `GridArray` view with ghosts if needed
- Add get/set buffer kernels to comm manager
- Only spawn threads when needed in comm manager
- Add test communicating a `GridArray`
