### PR TITLE
Fix threading correctness and add error monitoring

### DIFF
--- a/src/communication.jl
+++ b/src/communication.jl
@@ -328,6 +328,9 @@ function start!(A, cm::CommManagerTripleBuffered)
             getbuffer!(viewwithghosts(A), cm.recvbufferdevice, cm.pattern.recvindices)
             KernelAbstractions.synchronize(backend)
         end
+        @static if VERSION >= v"1.7"
+            cm.recvtask[] = errormonitor(cm.recvtask[])
+        end
     end
 
     if !isempty(cm.sendrequests)
@@ -338,6 +341,9 @@ function start!(A, cm::CommManagerTripleBuffered)
             copyto!(cm.sendbuffercomm, cm.sendbufferhost)
             MPI.Startall(cm.sendrequests)
             cooperative_testall(cm.sendrequests)
+        end
+        @static if VERSION >= v"1.7"
+            cm.sendtask[] = errormonitor(cm.sendtask[])
         end
     end
 

--- a/src/communication.jl
+++ b/src/communication.jl
@@ -141,6 +141,16 @@ function commmanager(T, comm, pattern, tag, ::Val{triplebuffer}) where {triplebu
     recvrequests = MPI.UnsafeMultiRequest(length(pattern.recvranks))
     sendrequests = MPI.UnsafeMultiRequest(length(pattern.sendranks))
 
+    if triplebuffer &&
+       (!isempty(recvrequests) || !isempty(sendrequests)) &&
+       MPI.Query_thread() < MPI.THREAD_MULTIPLE
+        throw(
+            ErrorException(
+                "CommManagerTripleBuffered calls MPI functions from multiple threads and thus MPI needs to be initialized with MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE).",
+            ),
+        )
+    end
+
     if triplebuffer
         recvbufferhost = Array{T}(undef, recvsize)
         sendbufferhost = Array{T}(undef, sendsize)

--- a/test/mpitest_n2_commgridarrays.jl
+++ b/test/mpitest_n2_commgridarrays.jl
@@ -6,7 +6,7 @@ using Raven
 using Raven.StaticArrays
 using Raven.Adapt
 
-MPI.Init()
+MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
 
 function test(::Type{FT}, ::Type{AT}) where {FT,AT}
     @testset "Communicate GridArray ($AT, $FT)" begin

--- a/test/mpitest_n3_communication.jl
+++ b/test/mpitest_n3_communication.jl
@@ -4,7 +4,7 @@ using MPI
 using Test
 using Raven
 
-MPI.Init()
+MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
 
 let
     mpisize = MPI.Comm_size(MPI.COMM_WORLD)

--- a/test/mpitest_n3_gridarrays.jl
+++ b/test/mpitest_n3_gridarrays.jl
@@ -7,7 +7,7 @@ using Raven.StaticArrays
 using LinearAlgebra
 using Raven.Adapt
 
-MPI.Init()
+MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
 
 struct Stiffness <: FieldArray{Tuple{2,2},Float64,2}
     xx::Float64

--- a/test/mpitest_n3_gridnumbering.jl
+++ b/test/mpitest_n3_gridnumbering.jl
@@ -6,7 +6,7 @@ using Raven
 using Raven.StaticArrays
 using Raven.P4estTypes
 
-MPI.Init()
+MPI.Init(; threadlevel = MPI.THREAD_MULTIPLE)
 
 function isisomorphic(a, b)
     f = Dict{eltype(a),eltype(b)}()


### PR DESCRIPTION
- Ensure MPI is initialized at correct thread level
- Add error monitoring to threads in communicator
